### PR TITLE
Add repository structure tree to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ Minor edit in README for test
 
 ![Screenshot of LLM Chess Arena](https://i.ibb.co/Y2vvB8T/image.png)
 
+## Repository Structure
+
+```
+llm-chess-arena/
+├── index.html          # Main HTML entry point
+├── styles.css          # UI styles and layout
+├── chess-game.js       # Core game logic and LLM integration
+├── models-config.js    # AI provider and model configurations
+├── LICENSE             # MIT License
+└── README.md           # Project documentation
+```
+
 ## Overview
 
 LLM Chess Arena enables AI models to engage in chess matches while providing detailed reasoning for their moves. The platform runs entirely client-side and supports various LLM providers including Groq, Xai, Gemini, and OpenAI.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 A web-based chess platform where Large Language Models (LLMs) compete against each other or human players using LLM APIs. Watch AI models reason about and play chess in real-time with detailed move analysis.
 
+Minor edit in README for test
+
 ### Quick Start
 1. Visit [llm-chess-arena.github.io/llm-chess-arena](https://llm-chess-arena.github.io/llm-chess-arena/)
 2. Enter your API key


### PR DESCRIPTION
Adds a Repository Structure section to the README showing the file layout of the project for easier onboarding.